### PR TITLE
fix maven-plugin and runner not working with JDK for "macosx.aarch64"

### DIFF
--- a/maven-plugin/rcptt-maven-util/src/main/java/org/eclipse/rcptt/maven/util/PlatformUtil.java
+++ b/maven-plugin/rcptt-maven-util/src/main/java/org/eclipse/rcptt/maven/util/PlatformUtil.java
@@ -24,20 +24,28 @@ public class PlatformUtil {
 
 	public static String getArch() {
 		String result = System.getProperty("os.arch"); //$NON-NLS-1$
-		switch (result.toLowerCase()) {
-		case "i386": //$NON-NLS-1$
-		case "i486": //$NON-NLS-1$
-		case "i586": //$NON-NLS-1$
-		case "i686": //$NON-NLS-1$
-		case "pentium": //$NON-NLS-1$
-			return "x86"; //$NON-NLS-1$
-		case "amd64": //$NON-NLS-1$
-		case "em64t": //$NON-NLS-1$
-		case "universal": //$NON-NLS-1$
-			return "x86_64"; //$NON-NLS-1$
-		default:
-			return result;
+		if (result != null) {
+			result = result.toLowerCase();
+			switch (result) {
+			case "x86": //$NON-NLS-1$
+			case "x86_64": //$NON-NLS-1$
+			case "aarch64": //$NON-NLS-1$
+				return result;
+			case "i386": //$NON-NLS-1$
+			case "i486": //$NON-NLS-1$
+			case "i586": //$NON-NLS-1$
+			case "i686": //$NON-NLS-1$
+			case "pentium": //$NON-NLS-1$
+				return "x86"; //$NON-NLS-1$
+			case "amd64": //$NON-NLS-1$
+			case "em64t": //$NON-NLS-1$
+			case "universal": //$NON-NLS-1$
+				return "x86_64"; //$NON-NLS-1$
+			default:
+				break;
+			}
 		}
+		throw new IllegalStateException(String.format("Unsupported \"os.arch\": %s", result)); //$NON-NLS-1$
 	}
 
 	public static OS getOS() {

--- a/maven-plugin/rcptt-maven-util/src/main/java/org/eclipse/rcptt/maven/util/PlatformUtil.java
+++ b/maven-plugin/rcptt-maven-util/src/main/java/org/eclipse/rcptt/maven/util/PlatformUtil.java
@@ -19,23 +19,33 @@ public class PlatformUtil {
 	 * @return The classifier of current platform in form of os.ws.arch
 	 */
 	public static String getEclipseClassifier() {
-		return String.format("%s.%s", getOS().classifier, getArch());
+		return String.format("%s.%s", getOS().classifier, getArch()); //$NON-NLS-1$
 	}
 
 	public static String getArch() {
-		String result = System.getProperty("os.arch");
-		if (result.contains("64") || getOS() == OS.MACOSX) {
-			return "x86_64";
+		String result = System.getProperty("os.arch"); //$NON-NLS-1$
+		switch (result.toLowerCase()) {
+		case "i386": //$NON-NLS-1$
+		case "i486": //$NON-NLS-1$
+		case "i586": //$NON-NLS-1$
+		case "i686": //$NON-NLS-1$
+		case "pentium": //$NON-NLS-1$
+			return "x86"; //$NON-NLS-1$
+		case "amd64": //$NON-NLS-1$
+		case "em64t": //$NON-NLS-1$
+		case "universal": //$NON-NLS-1$
+			return "x86_64"; //$NON-NLS-1$
+		default:
+			return result;
 		}
-		return "x86";
 	}
 
 	public static OS getOS() {
-		String osName = System.getProperty("os.name").toLowerCase();
-		if (osName.contains("win")) {
+		String osName = System.getProperty("os.name").toLowerCase(); //$NON-NLS-1$
+		if (osName.contains("win")) { //$NON-NLS-1$
 			return OS.WIN;
 		}
-		if (osName.contains("mac")) {
+		if (osName.contains("mac")) { //$NON-NLS-1$
 			return OS.MACOSX;
 		}
 		return OS.LINUX;

--- a/runner/features/org.eclipse.rcptt.runner.runner-feature/feature.xml
+++ b/runner/features/org.eclipse.rcptt.runner.runner-feature/feature.xml
@@ -600,6 +600,16 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.equinox.launcher.cocoa.macosx.aarch64"
+         os="macosx"
+         ws="cocoa"
+         arch="aarch64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"/>
+
+   <plugin
          id="org.eclipse.equinox.launcher.cocoa.macosx.x86_64"
          os="macosx"
          ws="cocoa"

--- a/runner/pom.xml
+++ b/runner/pom.xml
@@ -78,6 +78,11 @@
 							<ws>cocoa</ws>
 							<arch>x86_64</arch>
 						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>aarch64</arch>
+						</environment>
 					</environments>
 				</configuration>
 			</plugin>

--- a/runner/product/rcptt.runner.product
+++ b/runner/product/rcptt.runner.product
@@ -121,6 +121,7 @@
       <plugin id="org.eclipse.equinox.jsp.jasper"/>
       <plugin id="org.eclipse.equinox.jsp.jasper.registry"/>
       <plugin id="org.eclipse.equinox.launcher"/>
+      <plugin id="org.eclipse.equinox.launcher.cocoa.macosx.aarch64" fragment="true"/>
       <plugin id="org.eclipse.equinox.launcher.cocoa.macosx.x86_64" fragment="true"/>
       <plugin id="org.eclipse.equinox.launcher.gtk.linux.x86_64"/>
       <plugin id="org.eclipse.equinox.launcher.win32.win32.x86_64" fragment="true"/>
@@ -279,6 +280,7 @@
       <plugin id="org.eclipse.rcptt.watson.jobs"/>
       <plugin id="org.eclipse.rcptt.zephyr"/>
       <plugin id="org.eclipse.swt"/>
+      <plugin id="org.eclipse.swt.cocoa.macosx.aarch64" fragment="true"/>
       <plugin id="org.eclipse.swt.cocoa.macosx.x86_64" fragment="true"/>
       <plugin id="org.eclipse.swt.gtk.linux.x86_64"/>
       <plugin id="org.eclipse.swt.win32.win32.x86_64" fragment="true"/>


### PR DESCRIPTION
From https://bugs.eclipse.org/bugs/show_bug.cgi?id=581959:

I run Maven on macOS with a JDK for aarch64.  My Maven build assembles an Eclipse product for aarch64 but rcptt-maven-plugin fails my build.

First, the "rcptt-maven-plugin:resources" goal fails to find my Eclipse product.  The console output shows:
> [INFO] Sys arch is aarch64
> [INFO] classifier is not specified for AUT, setting to macosx.cocoa.x86_64 by default

This is a bug in org.eclipse.rcptt.maven.util.PlatformUtil.getArch() which incorrectly always returns "x86_64" on macOS.  I can work around this issue by adding an explicit "aut/classifier" tag in my pom.

Next, the "rcptt-maven-plugin:execute" goal is executed which launches the runner which fails with a bunch of "Could not resolve module" errors.  When I inspect the runner I see that its plugins directory only has the plugin fragments for x86_64 but not aarch64.

The pull request fixes both of these issues, correcting PlatformUtil.getArch() and updating the runner with the missing plugin fragments for "macosx.aarch64".  With those changes I can now build and test my Eclipse product for aarch64 on macOS from Maven.