### PR TITLE
Fix Illegal option: 'e' in '-eclipse.keyring'

### DIFF
--- a/launching/org.eclipse.rcptt.launching.ext/src/org/eclipse/rcptt/launching/ext/Q7ExternalLaunchDelegate.java
+++ b/launching/org.eclipse.rcptt.launching.ext/src/org/eclipse/rcptt/launching/ext/Q7ExternalLaunchDelegate.java
@@ -522,7 +522,7 @@ public class Q7ExternalLaunchDelegate extends
 		}
 		String override = configuration.getAttribute(
 				IQ7Launch.OVERRIDE_SECURE_STORAGE, (String) null);
-		if (override == null || "true".equals(override)) {
+		if ("true".equals(override)) {
 			// Override existing parameter
 			programArgs.add("-eclipse.keyring");
 			programArgs.add(getConfigDir(configuration).toString()

--- a/rcp/org.eclipse.rcptt.launching.configuration/src/org/eclipse/rcptt/launching/configuration/Q7LaunchConfigurationDelegate.java
+++ b/rcp/org.eclipse.rcptt.launching.configuration/src/org/eclipse/rcptt/launching/configuration/Q7LaunchConfigurationDelegate.java
@@ -230,7 +230,7 @@ public class Q7LaunchConfigurationDelegate extends
 		}
 		String override = configuration.getAttribute(
 				IQ7Launch.OVERRIDE_SECURE_STORAGE, (String) null);
-		if (override == null || "true".equals(override)) {
+		if ("true".equals(override)) {
 			// Override existing parameter
 			programArgs.add("-eclipse.keyring");
 			programArgs.add(getConfigDir(configuration).toString()


### PR DESCRIPTION
Do not use -eclipse.keyring by default.