### PR TITLE
Handle relative VM paths in AUT.ini on MacOS

### DIFF
--- a/build_runner.sh
+++ b/build_runner.sh
@@ -9,7 +9,7 @@
 # Contributors:
 # 	Xored Software Inc - initial API and implementation and/or initial documentation
 #*******************************************************************************
-export MAVEN_OPTS="-Xms512m -Xmx756m -XX:MaxPermSize=256m"
+export MAVEN_OPTS="-Xms512m -Xmx756m"
 
 OPTIONS="-Dtycho.localArtifacts=ignore $@"
 

--- a/devenv/launches/RCPTT Runner.launch
+++ b/devenv/launches/RCPTT Runner.launch
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
+    <booleanAttribute key="append.args" value="true"/>
+    <stringAttribute key="application" value="org.eclipse.rcptt.runner.headless"/>
+    <booleanAttribute key="askclear" value="false"/>
+    <booleanAttribute key="automaticAdd" value="false"/>
+    <booleanAttribute key="automaticIncludeRequirements" value="true"/>
+    <booleanAttribute key="automaticValidate" value="true"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <stringAttribute key="checked" value="[NONE]"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="true"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/RCPTT Runner"/>
+    <booleanAttribute key="default" value="false"/>
+    <setAttribute key="deselected_workspace_bundles"/>
+    <booleanAttribute key="includeOptional" value="false"/>
+    <stringAttribute key="location" value="${workspace_loc}/../runtime-RCPTTRunner"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog&#10;-aut /private/tmp/Eclipse.app -autArgs '-eclipse.password;/private/tmp/lablicate/exec-process/master' -autWsPrefix /private/tmp/lablicate/exec-process/../results/demo//aut-workspace- -autConsolePrefix /private/tmp/lablicate/exec-process/../results/demo//aut-out- -autVM /Users/vasiligulevich/.p2/pool/plugins/org.eclipse.justj.openjdk.hotspot.jre.full.macosx.aarch64_21.0.2.v20240123-0840/jre -htmlReport /private/tmp/lablicate/exec-process/../results/demo//results.html -junitReport /private/tmp/lablicate/exec-process/../results/demo//results.xml -import /private/tmp/lablicate/exec-process -tests exec-process.test"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.eclipse.rcptt.platform.product"/>
+    <setAttribute key="selected_target_bundles">
+        <setEntry value="org.eclipse.equinox.app@default:default"/>
+        <setEntry value="org.eclipse.equinox.p2.transport.ecf@default:default"/>
+        <setEntry value="org.eclipse.osgi.compatibility.state@default:false"/>
+        <setEntry value="org.eclipse.swt.cocoa.macosx.aarch64@default:false"/>
+    </setAttribute>
+    <setAttribute key="selected_workspace_bundles">
+        <setEntry value="org.eclipse.rcptt.ctx.workbench@default:default"/>
+        <setEntry value="org.eclipse.rcptt.runner@default:default"/>
+        <setEntry value="org.eclipse.rcptt.updates.aspectj.e44x@default:default"/>
+        <setEntry value="org.eclipse.rcptt.updates.kepler@default:default"/>
+        <setEntry value="org.eclipse.rcptt.updates.runtime.e4x@default:default"/>
+    </setAttribute>
+    <booleanAttribute key="show_selected_only" value="false"/>
+    <stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="true"/>
+    <booleanAttribute key="useProduct" value="false"/>
+</launchConfiguration>

--- a/launching/org.eclipse.rcptt.launching.ext/src/org/eclipse/rcptt/launching/internal/target/TargetPlatformHelper.java
+++ b/launching/org.eclipse.rcptt.launching.ext/src/org/eclipse/rcptt/launching/internal/target/TargetPlatformHelper.java
@@ -25,6 +25,8 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1030,11 +1032,17 @@ public class TargetPlatformHelper implements ITargetPlatformHelper {
 	}
 
 	public String getVmFromIniFile() {
-		for (File file : getAppIniFiles()) {
-			String result = getVmArg(file);
-			if (result != null) {
-				return result;
+		for (File iniFile : getAppIniFiles()) {
+			String result = getVmArg(iniFile);
+			if (result == null) {
+				continue;
 			}
+			Path iniPath = iniFile.toPath();
+			Path vmPath = Paths.get(result);
+			if (!vmPath.isAbsolute()) {
+				vmPath = iniPath.getParent().resolve(vmPath);
+			}
+			return vmPath.toString();
 		}
 		return null;
 	}

--- a/rcp/contexts/org.eclipse.rcptt.ctx.preferences.ui/.project
+++ b/rcp/contexts/org.eclipse.rcptt.ctx.preferences.ui/.project
@@ -25,4 +25,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1714208078953</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-true-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/runner/org.eclipse.rcptt.runner/.classpath
+++ b/runner/org.eclipse.rcptt.runner/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/runner/org.eclipse.rcptt.runner/.settings/org.eclipse.jdt.core.prefs
+++ b/runner/org.eclipse.rcptt.runner/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/runner/org.eclipse.rcptt.runner/src/org/eclipse/rcptt/runner/util/AUTsManager.java
+++ b/runner/org.eclipse.rcptt.runner/src/org/eclipse/rcptt/runner/util/AUTsManager.java
@@ -190,7 +190,7 @@ public class AUTsManager {
 		}
 		if (!file.exists()) {
 			System.out
-					.println(file + "does not exist");
+					.println(file + " does not exist");
 			return null;
 		}
 
@@ -205,6 +205,13 @@ public class AUTsManager {
 		if (file == null) {
 			System.out
 					.println("Unknown file system layout of Java VM from ini file");
+			return null;
+		}
+		
+		try {
+			file = file.getCanonicalFile();
+		} catch (IOException e) {
+			e.printStackTrace();
 			return null;
 		}
 

--- a/runner/org.eclipse.rcptt.runner/src/org/eclipse/rcptt/runner/util/AutThread.java
+++ b/runner/org.eclipse.rcptt.runner/src/org/eclipse/rcptt/runner/util/AutThread.java
@@ -209,12 +209,12 @@ public class AutThread extends Thread {
 						"org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/"
 								+ autVM);
 				config.setAttribute(IPDEConstants.APPEND_ARGS_EXPLICITLY, true);
-			}
-
-			String vmFromIni = manager.addJvmFromIniFile();
-			if (vmFromIni != null) {
-				config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_JRE_CONTAINER_PATH, vmFromIni);
-				config.setAttribute(IPDEConstants.APPEND_ARGS_EXPLICITLY, true);
+			} else {
+				String vmFromIni = manager.addJvmFromIniFile();
+				if (vmFromIni != null) {
+					config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_JRE_CONTAINER_PATH, vmFromIni);
+					config.setAttribute(IPDEConstants.APPEND_ARGS_EXPLICITLY, true);
+				}
 			}
 
 			if (conf.enableSoftwareInstallation)


### PR DESCRIPTION
Ignore AUT configuration if Runner is explicitly given a VM in command line. This changes the semantics of -autVM argument - now it takes priority over AUT's configuration.
Resolve VM paths relative to configuration file location.

Before this change, Runner logged errors even if  JVM was configured via command line:
```
Trying to use VM from application's ini file: ../Eclipse/features/net.openchrom.jre.macosx.cocoa.aarch64.feature_17.0.11/jre/jdk-17.0.11+9-jre/Contents/Home/lib/libjli.dylib
/private/tmp/Eclipse.app/../Eclipse/features/net.openchrom.jre.macosx.cocoa.aarch64.feature_17.0.11/jre/jdk-17.0.11+9-jre/Contents/Home/lib/libjli.dylibdoes not exist
AUT-0: Launch failed. Reason: FAIL: AUT requires aarch64 Java VM which cannot be found.
Please specify -autVM {javaPath} command line argument to use different JVM.
```
