### PR TITLE
Bug 572501: Do not suppress errors, fail if tests are not found

### DIFF
--- a/rcp/contexts/org.eclipse.rcptt.ctx.preferences.ui/src/org/eclipse/rcptt/ctx/preferences/ui/PreferencesContextEditor.java
+++ b/rcp/contexts/org.eclipse.rcptt.ctx.preferences.ui/src/org/eclipse/rcptt/ctx/preferences/ui/PreferencesContextEditor.java
@@ -187,8 +187,7 @@ public class PreferencesContextEditor extends BaseContextEditor {
 		Button importButton = toolkit.createButton(panel,
 				"Import Preferences...", SWT.PUSH);
 		GridDataFactory.fillDefaults().grab(true, false).applyTo(importButton);
-		importButton.setImage(Images.getImageDescriptor(
-				Images.PREFERENCES_IMPORT).createImage());
+		importButton.setImage(Images.getImage(Images.PREFERENCES_IMPORT));
 
 		importButton.addSelectionListener(new SelectionAdapter() {
 
@@ -203,8 +202,7 @@ public class PreferencesContextEditor extends BaseContextEditor {
 
 		Button addButton = toolkit.createButton(panel, "Add...", SWT.PUSH);
 		GridDataFactory.fillDefaults().grab(true, false).applyTo(addButton);
-		addButton.setImage(Images.getImageDescriptor(Images.PREFERENCES_IMPORT)
-				.createImage());
+		addButton.setImage(Images.getImage(Images.PREFERENCES_IMPORT));
 
 		addButton.addSelectionListener(new SelectionAdapter() {
 
@@ -220,8 +218,7 @@ public class PreferencesContextEditor extends BaseContextEditor {
 		Button removeButton = toolkit.createButton(panel, "Remove", SWT.PUSH);
 		GridDataFactory.fillDefaults().grab(true, false).applyTo(removeButton);
 		removeButton.setImage(PlatformUI.getWorkbench().getSharedImages()
-				.getImageDescriptor(ISharedImages.IMG_ETOOL_DELETE)
-				.createImage());
+				.getImage(ISharedImages.IMG_ETOOL_DELETE));
 		dbc.bindValue(WidgetProperties.enabled().observe(removeButton),
 				new ComputedValue<Boolean>() {
 

--- a/runner/org.eclipse.rcptt.runner/src/org/eclipse/rcptt/runner/HeadlessRunnerApp.java
+++ b/runner/org.eclipse.rcptt.runner/src/org/eclipse/rcptt/runner/HeadlessRunnerApp.java
@@ -59,6 +59,9 @@ public class HeadlessRunnerApp implements IApplication {
 			} else {
 				return returnTestFailure ? TEST_FAIL_EXIT_CODE : IApplication.EXIT_OK;
 			}
+		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
+			return ILLEGAL_ARGUMENT;
 		} catch (AutLaunchFail e) {
 			return AUT_FAIL_EXIT_CODE;
 		} catch (TargetPlatformFail e) {

--- a/runner/org.eclipse.rcptt.runner/src/org/eclipse/rcptt/runner/util/TestsRunner.java
+++ b/runner/org.eclipse.rcptt.runner/src/org/eclipse/rcptt/runner/util/TestsRunner.java
@@ -88,13 +88,10 @@ public class TestsRunner {
 
 		TestSuite[] tests;
 		tests = findScenarios();
-		if (tests.length > 0) {
-			return runTests(tests);
-		} else {
-			System.out.println("No tests to run.");
+		if (tests.length <= 0) {
+			throw new IllegalArgumentException("No tests found.");
 		}
-
-		return null;
+		return runTests(tests);
 	}
 
 	private static List<String> buildTestNamePatterns(List<String> globs) {
@@ -370,9 +367,6 @@ public class TestsRunner {
 			throw new RuntimeException(e1);
 		} catch (InterruptedException e) {
 			HeadlessRunnerPlugin.getDefault().info("Execution interrupted");
-		}
-		catch( Exception e ) {
-			HeadlessRunnerPlugin.getDefault().info("Unexpected error happened...", e);
 		}
 		finally {
 			skipRemaining(runnables, "Execution finished");


### PR DESCRIPTION
Runner should fail on AUT launch error or if no tests are found.
This is a backward incompatible change.

Fixes [bug 572501](https://bugs.eclipse.org/bugs/show_bug.cgi?id=572501)